### PR TITLE
fix the use in binary tf for document normalization

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pinecone-text"
-version = "0.3.3"
+version = "0.3.4"
 description = "Text utilities library by Pinecone.io"
 authors = ["Pinecone.io"]
 readme = "README.md"

--- a/tests/test_bm25.py
+++ b/tests/test_bm25.py
@@ -28,7 +28,7 @@ class TestBM25:
             os.remove(self.PARAMS_PATH)
 
     def get_token_hash(self, token, bm25: BM25):
-        return bm25._doc_freq_vectorizer.transform([token]).indices[0].item()
+        return bm25._tf_vectorizer.transform([token]).indices[0].item()
 
     def test_fit_default_params(self):
         assert self.bm25.n_docs == len(self.corpus)


### PR DESCRIPTION
1. fix the use in binary tf for document normalization. Now only IDF uses binary TF
2. Increase default vocabulary size and temporary limiting the maximum size until we refactor the implementation to support any unsigned 32 bits integer 