### PR TITLE
Allow torch 2.0.0 to work with pinecone-text while still supporting 1…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ packages = [{include = "pinecone_text"}]
 
 [tool.poetry.dependencies]
 python = ">=3.8,<4.0"
-torch = "^1.13.1"
+torch = ">=1.13.1"
 transformers = "^4.26.1"
 sentence-transformers = "^2.0.0"
 wget = "^3.2"


### PR DESCRIPTION
….13.1 version.

## Problem

torch = "^1.13.1" <<< This does not allow torch 2.0.1 to be compatible with pinecone-text. By default, torch 2.0.1 version is being installed and lot of other libraries are expecting 2.0.1.

So, forcing pinecone-text to be only working with 1.13.1 till 1.X.X makes pinecone-text difficult to work with, hence this change.

## Solution
torch = "^1.13.1"   >>> torch = ">=1.13.1"
This will allow the library to work with older version while still supporting latest torch versions.

## Type of Change
pyproject..toml change

## Test Plan

Installed the pinecone-text library with above changes and ran encoding operations successfully.

Example:
    from pinecone_text.sparse import BM25Encoder
    bm25 = BM25Encoder.default()
    sparse = bm25.encode_queries(user_msg)


