### PR TITLE
improve transformers import error message

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ If you wish to use SpladeEncoder, you will need to install the `torch` extra:
 pip install pincone-text[torch]
 ```
 
-
 ## Sparse Encoding
 
 To convert your own text corpus to sparse vectors, you can either use [BM25](https://www.pinecone.io/learn/semantic-search/#bm25) or [SPLADE](https://www.pinecone.io/learn/splade/).

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ To install the Pinecone Text Client, use the following command:
 pip install pinecone-text
 ```
 
-If you wish to use SpladeEncoder, you will need to install the `torch` extra:
+If you wish to use SpladeEncoder, you will need to install the `splade` extra:
 ```bash
-pip install pincone-text[torch]
+pip install pincone-text[splade]
 ```
 
 ## Sparse Encoding

--- a/pinecone_text/sparse/splade_encoder.py
+++ b/pinecone_text/sparse/splade_encoder.py
@@ -2,7 +2,7 @@ from typing import List, Union
 
 try:
     import torch
-except (OSError, ImportError) as e:
+except (OSError, ImportError, ModuleNotFoundError) as e:
     raise ImportError(
         """Failed to import torch. Make sure you install pytorch extra dependencies by running: `pip install pinecone-text[torch]`
 If this doesn't help, it is probably a CUDA error. If you do want to use GPU, please check your CUDA driver.
@@ -10,8 +10,13 @@ If you want to use CPU only, run the following command:
 `pip uninstall -y torch torchvision;pip install -y torch torchvision --index-url https://download.pytorch.org/whl/cpu`"""
     ) from e
 
+try:
+    from transformers import AutoTokenizer, AutoModelForMaskedLM
+except (ImportError, ModuleNotFoundError) as e:
+    raise ImportError(
+        "Failed to import transformers. Make sure you install pytorch extra dependencies by running: `pip install pinecone-text[torch]`"
+    ) from e
 
-from transformers import AutoTokenizer, AutoModelForMaskedLM
 from pinecone_text.sparse import SparseVector
 from pinecone_text.sparse.base_sparse_encoder import BaseSparseEncoder
 

--- a/pinecone_text/sparse/splade_encoder.py
+++ b/pinecone_text/sparse/splade_encoder.py
@@ -4,7 +4,7 @@ try:
     import torch
 except (OSError, ImportError, ModuleNotFoundError) as e:
     raise ImportError(
-        """Failed to import torch. Make sure you install pytorch extra dependencies by running: `pip install pinecone-text[torch]`
+        """Failed to import torch. Make sure you install pytorch extra dependencies by running: `pip install pinecone-text[splade]`
 If this doesn't help, it is probably a CUDA error. If you do want to use GPU, please check your CUDA driver.
 If you want to use CPU only, run the following command:
 `pip uninstall -y torch torchvision;pip install -y torch torchvision --index-url https://download.pytorch.org/whl/cpu`"""
@@ -14,7 +14,7 @@ try:
     from transformers import AutoTokenizer, AutoModelForMaskedLM
 except (ImportError, ModuleNotFoundError) as e:
     raise ImportError(
-        "Failed to import transformers. Make sure you install pytorch extra dependencies by running: `pip install pinecone-text[torch]`"
+        "Failed to import transformers. Make sure you install splade extra dependencies by running: `pip install pinecone-text[splade]`"
     ) from e
 
 from pinecone_text.sparse import SparseVector

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ mmh3 = "^3.1.0"
 nltk = "^3.6.5"
 
 [tool.poetry.extras]
-torch = ["torch", "transformers", "sentence-transformers"]
+slpade = ["torch", "transformers", "sentence-transformers"]
 
 [tool.poetry.group.dev]
 optional = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ mmh3 = "^3.1.0"
 nltk = "^3.6.5"
 
 [tool.poetry.extras]
-slpade = ["torch", "transformers", "sentence-transformers"]
+splade = ["torch", "transformers", "sentence-transformers"]
 
 [tool.poetry.group.dev]
 optional = true


### PR DESCRIPTION
## Problem

Error message for flailing to import transformers library doesn't indicate the need in installing torch extras.
Especially relevant for colab notebooks that comes with torch installed, but not transformers 

## Solution

Add a description about torch extras in the error message

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [X] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

CI tests are satisfying for this change
