### PR TITLE
ignore failures on splade import

### DIFF
--- a/pinecone_text/sparse/__init__.py
+++ b/pinecone_text/sparse/__init__.py
@@ -37,5 +37,6 @@ except ImportError:
         def __init__(self, *args, **kwargs):
             raise ImportError(
                 "Cannot use SpladeEncoder because the 'splade' package is not installed. "
-                "Please install it with 'pip install pinecone-text[splade]'."
+                "Please install it with 'pip install pinecone-text[splade]'. "
+                "And then run 'from pinecone_text.sparse.splade_encoder import SpladeEncoder' again."
             )

--- a/pinecone_text/sparse/__init__.py
+++ b/pinecone_text/sparse/__init__.py
@@ -28,14 +28,13 @@ SparseVector = Dict[str, Union[List[int], List[float]]]
 
 from pinecone_text.sparse.bm25_encoder import BM25Encoder
 
-# Try to import the SpladeEncoder. If it fails, and user tries to load it, raise an error.
+# Try to import the SpladeEncoder. If it fails, and user tries to init it, raise an error.
 try:
     from pinecone_text.sparse.splade_encoder import SpladeEncoder
 except ImportError:
-    class _FailingImport:
-        def __getattribute__(self, _):
+    class SpladeEncoder:
+        def __init__(self, *args, **kwargs):
             raise ImportError(
-                "Cannot import SpladeEncoder because the 'splade' package is not installed. "
+                "Cannot use SpladeEncoder because the 'splade' package is not installed. "
                 "Please install it with 'pip install pinecone-text[splade]'."
             )
-    SpladeEncoder = _FailingImport()

--- a/pinecone_text/sparse/__init__.py
+++ b/pinecone_text/sparse/__init__.py
@@ -28,13 +28,14 @@ SparseVector = Dict[str, Union[List[int], List[float]]]
 
 from pinecone_text.sparse.bm25_encoder import BM25Encoder
 
-# Try to import the SpladeEncoder. If it fails, and user tries to use it, raise an error.
+# Try to import the SpladeEncoder. If it fails, and user tries to load it, raise an error.
 try:
     from pinecone_text.sparse.splade_encoder import SpladeEncoder
-except (ImportError, ModuleNotFoundError):
-    SpladeEncoder = None
-    def SpladeEncoder(*args, **kwargs):
-        raise ImportError(
-            "Cannot use SpladeEncoder because the 'splade' extras is not installed. "
-            "Please install it with 'pip install pinecone-text[splade]'."
-        )
+except ImportError:
+    class _FailingImport:
+        def __getattribute__(self, _):
+            raise ImportError(
+                "Cannot import SpladeEncoder because the 'splade' package is not installed. "
+                "Please install it with 'pip install pinecone-text[splade]'."
+            )
+    SpladeEncoder = _FailingImport()

--- a/pinecone_text/sparse/__init__.py
+++ b/pinecone_text/sparse/__init__.py
@@ -28,15 +28,8 @@ SparseVector = Dict[str, Union[List[int], List[float]]]
 
 from pinecone_text.sparse.bm25_encoder import BM25Encoder
 
-# Try to import the SpladeEncoder. If it fails, and user tries to init it, raise an error.
+# Try to import the SpladeEncoder. If it fails, let the usage of the encoder fail.
 try:
     from pinecone_text.sparse.splade_encoder import SpladeEncoder
-except ImportError:
-
-    class SpladeEncoder:
-        def __init__(self, *args, **kwargs):
-            raise ImportError(
-                "Cannot use SpladeEncoder because the 'splade' package is not installed. "
-                "Please install it with 'pip install pinecone-text[splade]'. "
-                "And then run 'from pinecone_text.sparse.splade_encoder import SpladeEncoder' again."
-            )
+except (ImportError, ModuleNotFoundError):
+    pass

--- a/pinecone_text/sparse/__init__.py
+++ b/pinecone_text/sparse/__init__.py
@@ -22,6 +22,7 @@ This allows a semantic search to be performed on the sparse vectors. The SPLADE 
 For more information, see the [SPLADE paper](https://arxiv.org/abs/2109.10086). The SPLADE encoder is currently only available for inference only.
 """
 
+import logging
 from typing import Union, Dict, List
 
 SparseVector = Dict[str, Union[List[int], List[float]]]
@@ -32,4 +33,6 @@ from pinecone_text.sparse.bm25_encoder import BM25Encoder
 try:
     from pinecone_text.sparse.splade_encoder import SpladeEncoder
 except (ImportError, ModuleNotFoundError):
-    pass
+    logging.warning(
+        "Failed to import splade encoder. If you want to use splade, install the splade extra dependencies by running: `pip install pinecone-text[splade]`"
+    )

--- a/pinecone_text/sparse/__init__.py
+++ b/pinecone_text/sparse/__init__.py
@@ -27,4 +27,14 @@ from typing import Union, Dict, List
 SparseVector = Dict[str, Union[List[int], List[float]]]
 
 from pinecone_text.sparse.bm25_encoder import BM25Encoder
-from pinecone_text.sparse.splade_encoder import SpladeEncoder
+
+# Try to import the SpladeEncoder. If it fails, and user tries to use it, raise an error.
+try:
+    from pinecone_text.sparse.splade_encoder import SpladeEncoder
+except (ImportError, ModuleNotFoundError):
+    SpladeEncoder = None
+    def SpladeEncoder(*args, **kwargs):
+        raise ImportError(
+            "Cannot use SpladeEncoder because the 'splade' extras is not installed. "
+            "Please install it with 'pip install pinecone-text[splade]'."
+        )

--- a/pinecone_text/sparse/__init__.py
+++ b/pinecone_text/sparse/__init__.py
@@ -32,6 +32,7 @@ from pinecone_text.sparse.bm25_encoder import BM25Encoder
 try:
     from pinecone_text.sparse.splade_encoder import SpladeEncoder
 except ImportError:
+
     class SpladeEncoder:
         def __init__(self, *args, **kwargs):
             raise ImportError(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pinecone-text"
-version = "0.5.0"
+version = "0.5.1"
 description = "Text utilities library by Pinecone.io"
 authors = ["Pinecone.io"]
 readme = "README.md"


### PR DESCRIPTION
## Problem

When importing sparse module without installing the splade extra, there is an import error raised

## Solution

Ignore import error in the module init, and raise an error only if the user is trying to use spalde encoder

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

CI and manual test on clean env