### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ pip install pinecone-text
 
 If you wish to use `SpladeEncoder`, you will need to install the `splade` extra:
 ```bash
-pip install pincone-text[splade]
+pip install pinecone-text[splade]
 ```
 
 If you wish to use `SentenceTransformerEncoder` dense encoder, you will need to install the `dense` extra:
 ```bash
-pip install pincone-text[dense]
+pip install pinecone-text[dense]
 ```
 
 ## Sparse Encoding


### PR DESCRIPTION
FIx typos in pip install commands

## Problem

Typo in the pip install commands in the README.md for splade and SentenceTransformers

## Solution

Fixed the typo so you can copy and paste and install.

## Test Plan

I installed the package with the new change
