### PR TITLE
Restrict numpy versions to be compatible with NLTK

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pinecone-text"
-version = "0.6.0"
+version = "0.6.1"
 description = "Text utilities library by Pinecone.io"
 authors = ["Pinecone.io"]
 readme = "README.md"
@@ -14,7 +14,7 @@ sentence-transformers = { version = ">=2.0.0", optional = true }
 wget = "^3.2"
 mmh3 = "^3.1.0"
 nltk = "^3.6.5"
-numpy = "^1.21.5"
+numpy = ">=1.21.5,<=1.25.2"
 openai =  { version = "^0.27.3", optional = true }
 
 [tool.poetry.extras]


### PR DESCRIPTION
## Problem

Latest numpy version (1.26.1) is not compatible with NLTK

Error:

AttributeError                            Traceback (most recent call last)
[<ipython-input-6-1d2184025e54>](https://localhost:8080/#) in <cell line: 1>()
----> 1 import nltk

7 frames
[/usr/local/lib/python3.10/dist-packages/numpy/testing/_private/utils.py](https://localhost:8080/#) in <module>
     55 IS_PYSTON = hasattr(sys, "pyston_version_info")
     56 HAS_REFCOUNT = getattr(sys, 'getrefcount', None) is not None and not IS_PYSTON
---> 57 HAS_LAPACK64 = numpy.linalg._umath_linalg._ilp64
     58 
     59 _OLD_PROMOTION = lambda: np._get_promotion_state() == 'legacy'

AttributeError: module 'numpy.linalg._umath_linalg' has no attribute '_ilp64'

## Solution

Restrict numpy versions to not exceed 1.26

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Existing tests hold
