### PR TITLE
Azure OpenAI encoder

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -46,4 +46,9 @@ jobs:
       env:
          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
          CO_API_KEY: ${{ secrets.CO_API_KEY }}
+         AZURE_OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}
+         AZURE_OPENAI_ENDPOINT: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
+         OPENAI_API_VERSION: ${{ secrets.OPENAI_API_VERSION }}
+         EMBEDDINGS_AZURE_OPENAI_DEPLOYMENT_NAME: ${{ secrets.EMBEDDINGS_AZURE_OPENAI_DEPLOYMENT_NAME }}
+
       run: poetry run pytest tests/system

--- a/README.md
+++ b/README.md
@@ -162,6 +162,9 @@ encoder.encode_queries(["Who jumped over the lazy dog?"])
 # [[0.11, 0.43, 0.67, ...]]
 ```
 
+Pinecone text also supports Azure OpenAI API. To use it, you need to import the `AzureOpenAIEncoder` class instead of `OpenAIEncoder`. You also need to pass Azure specific environment variables to the constructor, along with your specific embeddings  deployment as the model name. For more information please follow the `AzureOpenAIEncoder` documentation.
+
+
 ## Combining Sparse and Dense Encodings for Hybrid Search
 To combine sparse and dense encodings for hybrid search, you can use the `hybrid_convex_scale` method on your query.
 

--- a/pinecone_text/dense/__init__.py
+++ b/pinecone_text/dense/__init__.py
@@ -1,3 +1,3 @@
 from .cohere_encoder import CohereEncoder
-from .openai_encoder import OpenAIEncoder
+from .openai_encoder import OpenAIEncoder, AzureOpenAIEncoder
 from .sentence_transformer_encoder import SentenceTransformerEncoder

--- a/pinecone_text/dense/openai_encoder.py
+++ b/pinecone_text/dense/openai_encoder.py
@@ -1,3 +1,4 @@
+import os
 from typing import Union, List, Any, Optional
 from pinecone_text.dense.base_dense_ecoder import BaseDenseEncoder
 
@@ -41,6 +42,78 @@ class OpenAIEncoder(BaseDenseEncoder):
         self._model_name = model_name
         self._client = openai.OpenAI(
             api_key=api_key, organization=organization, base_url=base_url, **kwargs
+        )
+
+    def encode_documents(
+        self, texts: Union[str, List[str]]
+    ) -> Union[List[float], List[List[float]]]:
+        return self._encode(texts)
+
+    def encode_queries(
+        self, texts: Union[str, List[str]]
+    ) -> Union[List[float], List[List[float]]]:
+        return self._encode(texts)
+
+    def _encode(
+        self, texts: Union[str, List[str]]
+    ) -> Union[List[float], List[List[float]]]:
+        if isinstance(texts, str):
+            texts_input = [texts]
+        elif isinstance(texts, list):
+            texts_input = texts
+        else:
+            raise ValueError(
+                f"texts must be a string or list of strings, got: {type(texts)}"
+            )
+
+        try:
+            response = self._client.embeddings.create(
+                input=texts_input, model=self._model_name
+            )
+        except OpenAIError as e:
+            # TODO: consider wrapping external provider errors
+            raise e
+
+        if isinstance(texts, str):
+            return response.data[0].embedding
+        return [result.embedding for result in response.data]
+
+
+class AzureOpenAIEncoder(BaseDenseEncoder):
+    """
+    OpenAI's text embedding wrapper. See https://platform.openai.com/docs/guides/embeddings
+
+    Note: You should provide an API key and organization in the environment variables OPENAI_API_KEY and OPENAI_ORG.
+          Or you can pass them as arguments to the constructor as `api_key` and `organization`.
+    """
+
+    def __init__(
+        self,
+        model_name: str = "text-embedding-ada-002",
+        api_key: Optional[str] = None,
+        organization: Optional[str] = None,
+        base_url: Optional[str] = None,
+        **kwargs: Any,
+    ):
+        """
+        Initialize the OpenAI encoder.
+
+        :param model_name: The name of the embedding model to use. See https://beta.openai.com/docs/api-reference/embeddings
+        :param kwargs: Additional arguments to pass to the underlying openai client. See https://github.com/openai/openai-python
+        """
+        if not _openai_installed:
+            raise ImportError(
+                "Failed to import openai. Make sure you install openai extra "
+                "dependencies by running: "
+                "`pip install pinecone-text[openai]"
+            )
+        self._model_name = model_name
+        self._client = openai.AzureOpenAI(
+            api_key=api_key,
+            api_version="2023-05-15",
+            azure_endpoint=os.getenv("AZURE_OPENAI_ENDPOINT"),
+            base_url=base_url,
+            **kwargs,
         )
 
     def encode_documents(

--- a/pinecone_text/dense/openai_encoder.py
+++ b/pinecone_text/dense/openai_encoder.py
@@ -15,24 +15,31 @@ class OpenAIEncoder(BaseDenseEncoder):
     """
     OpenAI's text embedding wrapper. See https://platform.openai.com/docs/guides/embeddings
 
-    Note: You should provide an API key and organization in the environment variables OPENAI_API_KEY and OPENAI_ORG.
-          Or you can pass them as arguments to the constructor as `api_key` and `organization`.
-    """
+    Note: this method reflects the OpenAI client initialization behaviour (See https://github.com/openai/openai-python/blob/main/src/openai/_client.py)
+      On initialization, You may explicitly pass any argument that the OpenAI client accepts, or use the following environment variables:
+
+    - `OPENAI_API_KEY` as `api_key`
+    - `OPENAI_ORG_ID` as `organization`
+    - `OPENAI_BASE_URL` as `base_url`
+
+    Example:
+        Using environment variables:
+        >>> import os
+        >>> from pinecone_text.dense import OpenAIEncoder
+        >>> os.environ['OPENAI_API_KEY'] = "sk-..."
+        >>> encoder = OpenAIEncoder()
+        >>> encoder.encode_documents(["some text", "some other text"])
+
+        Passing arguments explicitly:
+        >>> from pinecone_text.dense import OpenAIEncoder
+        >>> encoder = OpenAIEncoder(api_key="sk-...")
+    """  # noqa: E501
 
     def __init__(
         self,
         model_name: str = "text-embedding-ada-002",
-        api_key: Optional[str] = None,
-        organization: Optional[str] = None,
-        base_url: Optional[str] = None,
         **kwargs: Any,
     ):
-        """
-        Initialize the OpenAI encoder.
-
-        :param model_name: The name of the embedding model to use. See https://beta.openai.com/docs/api-reference/embeddings
-        :param kwargs: Additional arguments to pass to the underlying openai client. See https://github.com/openai/openai-python
-        """
         if not _openai_installed:
             raise ImportError(
                 "Failed to import openai. Make sure you install openai extra "
@@ -40,9 +47,11 @@ class OpenAIEncoder(BaseDenseEncoder):
                 "`pip install pinecone-text[openai]"
             )
         self._model_name = model_name
-        self._client = openai.OpenAI(
-            api_key=api_key, organization=organization, base_url=base_url, **kwargs
-        )
+        self._client = self._create_client(**kwargs)
+
+    @staticmethod
+    def _create_client(**kwargs: Any) -> Union[openai.OpenAI, openai.AzureOpenAI]:
+        return openai.OpenAI(**kwargs)
 
     def encode_documents(
         self, texts: Union[str, List[str]]
@@ -66,58 +75,52 @@ class OpenAIEncoder(BaseDenseEncoder):
                 f"texts must be a string or list of strings, got: {type(texts)}"
             )
 
-        batch_size = 16  # Azure OpenAI limit as of 2023-11-27
-        result = []
-        for i in range(0, len(texts), batch_size):
-            batch = texts[i : i + batch_size]
-            try:
-                response = self._client.embeddings.create(
-                    input=batch, model=self._model_name
-                )
-            except OpenAIError as e:
-                # TODO: consider wrapping external provider errors
-                raise e
+        try:
+            response = self._client.embeddings.create(
+                input=texts_input, model=self._model_name
+            )
+        except OpenAIError as e:
+            # TODO: consider wrapping external provider errors
+            raise e
 
-            if isinstance(batch, str):
-                result.extend(response.data[0].embedding)
-            result.extend([result.embedding for result in response.data])
-
-        return result
+        if isinstance(texts, str):
+            return response.data[0].embedding
+        return [result.embedding for result in response.data]
 
 
 class AzureOpenAIEncoder(OpenAIEncoder):
     """
-    Azure OpenAI's text embedding wrapper.
-    See https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/understand-embeddings
+    Initialize the Azure OpenAI encoder.
 
-    Note: You should provide an API key in the environment variables AZURE_OPENAI_API_KEY.
-          Or you can pass it as an arguments to the constructor as `api_key`.
-    """
+    Note: this method reflects the AzureOpenAI client initialization behaviour (See https://github.com/openai/openai-python/blob/main/src/openai/lib/azure.py).
+           You may explicitly pass any argument that the AzureOpenAI client accepts, or use the following environment variables:
 
-    def __init__(
-        self,
-        model_name: str = "text-embedding-ada-002",
-        api_key: Optional[str] = None,
-        base_url: Optional[str] = None,
-        **kwargs: Any,
-    ):
-        """
-        Initialize the OpenAI encoder.
+        - `AZURE_OPENAI_API_KEY` as `api_key`
+        - `AZURE_OPENAI_ENDPOINT` as `azure_endpoint`
+        - `OPENAI_API_VERSION` as `api_version`
+        - `OPENAI_ORG_ID` as `organization`
+        - `AZURE_OPENAI_AD_TOKEN` as `azure_ad_token`
 
-        :param model_name: The name of the embedding model to use. See https://beta.openai.com/docs/api-reference/embeddings
-        :param kwargs: Additional arguments to pass to the underlying openai client. See https://github.com/openai/openai-python
-        """
-        if not _openai_installed:
-            raise ImportError(
-                "Failed to import openai. Make sure you install openai extra "
-                "dependencies by running: "
-                "`pip install pinecone-text[openai]"
-            )
-        self._model_name = model_name
-        self._client = openai.AzureOpenAI(
-            api_key=api_key,
-            api_version="2023-05-15",
-            azure_endpoint=os.getenv("AZURE_OPENAI_ENDPOINT"),
-            base_url=base_url,
-            **kwargs,
-        )
+    In addition, you must pass the `model_name` argument with the name of the deployment you wish to use in your own Azure account.
+
+    Example:
+        Using environment variables:
+        >>> import os
+        >>> from pinecone_text.dense import AzureOpenAIEncoder
+        >>> os.environ['AZURE_OPENAI_API_KEY'] = "sk-..."
+        >>> os.environ['AZURE_OPENAI_ENDPOINT'] = "https://.....openai.azure.com/"
+        >>> os.environ['OPENAI_API_VERSION'] = "2023-12-01-preview"
+        >>> encoder = AzureOpenAIEncoder(model_name="my-ada-002-deployment")
+        >>> encoder.encode_documents(["some text", "some other text"])
+
+        Passing arguments explicitly:
+        >>> from pinecone_text.dense import AzureOpenAIEncoder
+        >>> encoder = AzureOpenAIEncoder(api_key="sk-...", azure_endpoint="https://.....openai.azure.com/", api_version="2023-12-01-preview")
+    """  # noqa: E501
+
+    def __init__(self, model_name: str, **kwargs: Any):
+        super().__init__(model_name=model_name, **kwargs)
+
+    @staticmethod
+    def _create_client(**kwargs: Any) -> openai.AzureOpenAI:
+        return openai.AzureOpenAI(**kwargs)

--- a/pinecone_text/dense/openai_encoder.py
+++ b/pinecone_text/dense/openai_encoder.py
@@ -79,19 +79,19 @@ class OpenAIEncoder(BaseDenseEncoder):
         return [result.embedding for result in response.data]
 
 
-class AzureOpenAIEncoder(BaseDenseEncoder):
+class AzureOpenAIEncoder(OpenAIEncoder):
     """
-    OpenAI's text embedding wrapper. See https://platform.openai.com/docs/guides/embeddings
+    Azure OpenAI's text embedding wrapper.
+    See https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/understand-embeddings
 
-    Note: You should provide an API key and organization in the environment variables OPENAI_API_KEY and OPENAI_ORG.
-          Or you can pass them as arguments to the constructor as `api_key` and `organization`.
+    Note: You should provide an API key in the environment variables AZURE_OPENAI_API_KEY.
+          Or you can pass it as an arguments to the constructor as `api_key`.
     """
 
     def __init__(
         self,
         model_name: str = "text-embedding-ada-002",
         api_key: Optional[str] = None,
-        organization: Optional[str] = None,
         base_url: Optional[str] = None,
         **kwargs: Any,
     ):
@@ -115,37 +115,3 @@ class AzureOpenAIEncoder(BaseDenseEncoder):
             base_url=base_url,
             **kwargs,
         )
-
-    def encode_documents(
-        self, texts: Union[str, List[str]]
-    ) -> Union[List[float], List[List[float]]]:
-        return self._encode(texts)
-
-    def encode_queries(
-        self, texts: Union[str, List[str]]
-    ) -> Union[List[float], List[List[float]]]:
-        return self._encode(texts)
-
-    def _encode(
-        self, texts: Union[str, List[str]]
-    ) -> Union[List[float], List[List[float]]]:
-        if isinstance(texts, str):
-            texts_input = [texts]
-        elif isinstance(texts, list):
-            texts_input = texts
-        else:
-            raise ValueError(
-                f"texts must be a string or list of strings, got: {type(texts)}"
-            )
-
-        try:
-            response = self._client.embeddings.create(
-                input=texts_input, model=self._model_name
-            )
-        except OpenAIError as e:
-            # TODO: consider wrapping external provider errors
-            raise e
-
-        if isinstance(texts, str):
-            return response.data[0].embedding
-        return [result.embedding for result in response.data]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pinecone-text"
-version = "0.7.1"
+version = "0.7.2"
 description = "Text utilities library by Pinecone.io"
 authors = ["Pinecone.io"]
 readme = "README.md"


### PR DESCRIPTION
## Problem

Azure OpenAI can't be used with this library. I stumbled upon this issue when I tried to implement the Azure OpenAI client for use with the *canopy-sdk*. 

## Solution

This PR implements the dense encoder using the Azure OpenAI embeddings. I subclassed a new encoder from the existing `OpenAIEncoder` and used the `AzureOpenAI` client. 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

No specific tests were added as the existing `OpenAIEncoder` tests should cover all use cases. 
