### PR TITLE
CI - Run system tests on merge_queue

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -45,4 +45,5 @@ jobs:
       if: github.event_name == 'merge_group'
       env:
          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+         CO_API_KEY: ${{ secrets.CO_API_KEY }}
       run: poetry run pytest tests/system

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -1,6 +1,8 @@
 name: Pull-request CI
 
-on: push
+on:
+  - pull_request
+  - merge_group
 
 jobs:
   run-tests:
@@ -36,7 +38,11 @@ jobs:
 
     - run: poetry run mypy .
 
-    - name: Run tests
+    - name: Run unit tests
+      run: poetry run pytest tests/unit
+
+    - name: Run system tests
+      if: github.event_name == 'merge_group'
       env:
          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-      run: poetry run pytest tests
+      run: poetry run pytest tests/system


### PR DESCRIPTION
## Problem

A. Tests did not run for pushes from forks
B. We don't want to allow PRs to access secrets until they were approved

## Solution

This allows system tests to access repo secretes, after a PR has been approved

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [X] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Sort of recursive, isn't it...?