### PR TITLE
fix naming in query encoding

### DIFF
--- a/pinecone_text/sparse/bm25_encoder.py
+++ b/pinecone_text/sparse/bm25_encoder.py
@@ -152,8 +152,8 @@ class BM25Encoder(BaseSparseEncoder):
     def _encode_single_query(self, text: str) -> SparseVector:
         indices, query_tf = self._tf(text)
 
-        tf = np.array([self.doc_freq.get(idx, 1) for idx in indices])  # type: ignore
-        idf = np.log((self.n_docs + 1) / (tf + 0.5))  # type: ignore
+        df = np.array([self.doc_freq.get(idx, 1) for idx in indices])  # type: ignore
+        idf = np.log((self.n_docs + 1) / (df + 0.5))  # type: ignore
         idf_norm = idf / idf.sum()
         return {
             "indices": indices,


### PR DESCRIPTION
## Problem

Name of DF in query encoding is currently `tf`

## Solution

Rename the variable.

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Describe specific steps for validating this change.
