### PR TITLE
Bump version and change openai default model

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,12 +158,12 @@ encoder.encode_queries(["Who jumped over the lazy dog?"])
 
 When using the `OpenAIEncoder`, you need to provide an API key for the OpenAI API, and store it in the `OPENAI_API_KEY` environment variable before you import the encoder.
 
-By default the encoder will use `text-embedding-ada-002` as recommended by OpenAI. You can also specify a different model name using the `model_name` parameter.
+By default the encoder will use `text-embedding-3-small` as recommended by OpenAI. You can also specify a different model name using the `model_name` parameter.
 #### Usage
 ```python
 from pinecone_text.dense import OpenAIEncoder
 
-encoder = OpenAIEncoder() # defaults to the recommended model - "text-embedding-ada-002"
+encoder = OpenAIEncoder() # defaults to the recommended model - "text-embedding-3-small"
 
 encoder.encode_documents(["The quick brown fox jumps over the lazy dog"])
 # [[0.21, 0.38, 0.15, ...]]
@@ -186,7 +186,7 @@ By default the encoder will use `jina-embeddings-v2-base-en`. You can also speci
 ```python
 from pinecone_text.dense import JinaEncoder
 
-encoder = JinaEncoder() # defaults to the recommended model - "text-embedding-ada-002"
+encoder = JinaEncoder()
 
 encoder.encode_documents(["The quick brown fox jumps over the lazy dog"])
 # [[-0.62586284, -0.54578537, 0.5570845, ...]]

--- a/pinecone_text/dense/openai_encoder.py
+++ b/pinecone_text/dense/openai_encoder.py
@@ -37,7 +37,7 @@ class OpenAIEncoder(BaseDenseEncoder):
 
     def __init__(
         self,
-        model_name: str = "text-embedding-ada-002",
+        model_name: str = "text-embedding-3-small",
         *,
         dimension: Optional[int] = None,
         **kwargs: Any,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pinecone-text"
-version = "0.7.2"
+version = "0.8.0"
 description = "Text utilities library by Pinecone.io"
 authors = ["Pinecone.io"]
 readme = "README.md"


### PR DESCRIPTION
## Problem

OpenAI released a new version of their embedding model, which is now their recommendation
 
## Solution

change default model

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Same tests apply