### PR TITLE
Add mmh3 4.X as dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ transformers = { version = ">=4.26.1", optional = true }
 sentence-transformers = { version = ">=2.0.0", optional = true }
 wget = "^3.2"
 mmh3 = ">3.1.0"
-nltk = "^3.6.5"
+nltk = "^4.1.0""
 openai =  { version = "^1.2.3", optional = true }
 cohere = { version = "^4.37", optional = true }
 numpy = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ torch = { version = ">=1.13.1", optional = true }
 transformers = { version = ">=4.26.1", optional = true }
 sentence-transformers = { version = ">=2.0.0", optional = true }
 wget = "^3.2"
-mmh3 = "^3.1.0"
+mmh3 = "^4.1.0"
 nltk = "^3.6.5"
 openai =  { version = "^1.2.3", optional = true }
 cohere = { version = "^4.37", optional = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,8 @@ torch = { version = ">=1.13.1", optional = true }
 transformers = { version = ">=4.26.1", optional = true }
 sentence-transformers = { version = ">=2.0.0", optional = true }
 wget = "^3.2"
-mmh3 = ">3.1.0"
-nltk = "^4.1.0""
+mmh3 = "^4.1.0"
+nltk = "^3.6.5"
 openai =  { version = "^1.2.3", optional = true }
 cohere = { version = "^4.37", optional = true }
 numpy = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pinecone-text"
-version = "0.8.0"
+version = "0.9.0"
 description = "Text utilities library by Pinecone.io"
 authors = ["Pinecone.io"]
 readme = "README.md"
@@ -12,7 +12,7 @@ torch = { version = ">=1.13.1", optional = true }
 transformers = { version = ">=4.26.1", optional = true }
 sentence-transformers = { version = ">=2.0.0", optional = true }
 wget = "^3.2"
-mmh3 = "^4.1.0"
+mmh3 = ">3.1.0"
 nltk = "^3.6.5"
 openai =  { version = "^1.2.3", optional = true }
 cohere = { version = "^4.37", optional = true }


### PR DESCRIPTION
## Problem

pinecone-text and llama-index cannot be installed simultaneously because of a
dependency issue with mmh3. pinecone-text is locked to use 3.1 where llama-index uses version 4. or greater

Please note that version 4 of mmh3 had a breaking change with big-endian platforms.

## Solution

Bump the supported version of mmh3. to include version 4.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Tested it locally

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206790848310901