### PR TITLE
allow mmh3 4.X

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ torch = { version = ">=1.13.1", optional = true }
 transformers = { version = ">=4.26.1", optional = true }
 sentence-transformers = { version = ">=2.0.0", optional = true }
 wget = "^3.2"
-mmh3 = "^3.1.0 || ^4.0.0"
+mmh3 = ">3.1.0"
 nltk = "^3.6.5"
 openai =  { version = "^1.2.3", optional = true }
 cohere = { version = "^4.37", optional = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pinecone-text"
-version = "0.8.0"
+version = "0.9.0"
 description = "Text utilities library by Pinecone.io"
 authors = ["Pinecone.io"]
 readme = "README.md"
@@ -12,7 +12,7 @@ torch = { version = ">=1.13.1", optional = true }
 transformers = { version = ">=4.26.1", optional = true }
 sentence-transformers = { version = ">=2.0.0", optional = true }
 wget = "^3.2"
-mmh3 = "^3.1.0"
+mmh3 = "^3.1.0 || ^4.0.0"
 nltk = "^3.6.5"
 openai =  { version = "^1.2.3", optional = true }
 cohere = { version = "^4.37", optional = true }


### PR DESCRIPTION
## Problem

Some users got into a dependency hell due to restriction of mmh3 to be 3.X and not allowing 4.X

## Solution

Allow mmh3 4.X, according to the docs and some local tests there is no difference in encodings.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [X] None of the above: non breaking dependency update

## Test Plan

Tested locally comparison between versions to make sure the aligned, also CI have tests for BM25 and I run with both versions