### PR TITLE
Replace deprecated 'punkt' with 'punkt_tab'

### DIFF
--- a/pinecone_text/sparse/bm25_tokenizer.py
+++ b/pinecone_text/sparse/bm25_tokenizer.py
@@ -34,9 +34,9 @@ class BM25Tokenizer:
     @staticmethod
     def nltk_setup() -> None:
         try:
-            nltk.data.find("tokenizers/punkt")
+            nltk.data.find("tokenizers/punkt_tab")
         except LookupError:
-            nltk.download("punkt")
+            nltk.download("punkt_tab")
 
         try:
             nltk.data.find("corpora/stopwords")

--- a/tests/unit/test_bm25_tokenizer.py
+++ b/tests/unit/test_bm25_tokenizer.py
@@ -152,7 +152,7 @@ class TestBM25Tokenizer:
             language="english",
         )
 
-        nltk.find("tokenizers/punkt")
+        nltk.find("tokenizers/punkt_tab")
         nltk.find("corpora/stopwords")
 
         assert tokenizer("The quick brown fox jumps over the lazy dog") == [


### PR DESCRIPTION
## Problem

The NLTK package `punkt` has been [deprecated](https://github.com/nltk/nltk/issues/3293), resulting in an error when calling a BM25Tokenizer

<img width="412" alt="image" src="https://github.com/user-attachments/assets/ac6b6e98-c5b7-4c73-8fe0-3183a28bb03a">


## Solution

Replace `punkt` with the new `punkt_tab`

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

This might be a breaking change. NLTK 3.8.1 and lower use `punkt` whereas NLTK 3.8.2 and above will use `punkt_tab`. The `pyproject.toml` file references `nltk = "^3.6.5"`, meaning it will install NLTK 3.8.2 if possible, thus breaking. Introducing this breaking change on a patch version is something that the NLTK maintainers not should have done, but alas.

Another fix would be to freeze the NLTK version.

## Test Plan

I tried it locally and it fixed my issue.
