### PR TITLE
Upgrade NLTK version to ^3.91 + stop support python 3.8

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        python-version: [3.8, 3.9, '3.10', 3.11, 3.12]
+        python-version: [3.9, '3.10', 3.11, 3.12]
     defaults:
       run:
         shell: bash

--- a/pinecone_text/sparse/bm25_tokenizer.py
+++ b/pinecone_text/sparse/bm25_tokenizer.py
@@ -34,9 +34,9 @@ class BM25Tokenizer:
     @staticmethod
     def nltk_setup() -> None:
         try:
-            nltk.data.find("tokenizers/punkt")
+            nltk.data.find("tokenizers/punkt_tab")
         except LookupError:
-            nltk.download("punkt")
+            nltk.download("punkt_tab")
 
         try:
             nltk.data.find("corpora/stopwords")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 packages = [{include = "pinecone_text"}]
 
 [tool.poetry.dependencies]
-python = ">=3.8,<4.0"
+python = ">=3.9,<4.0"
 torch = { version = ">=1.13.1", optional = true }
 transformers = { version = ">=4.26.1", optional = true }
 sentence-transformers = { version = ">=2.0.0", optional = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pinecone-text"
-version = "0.9.0"
+version = "0.10.0"
 description = "Text utilities library by Pinecone.io"
 authors = ["Pinecone.io"]
 readme = "README.md"
@@ -13,7 +13,7 @@ transformers = { version = ">=4.26.1", optional = true }
 sentence-transformers = { version = ">=2.0.0", optional = true }
 wget = "^3.2"
 mmh3 = "^4.1.0"
-nltk = "^3.6.5"
+nltk = "^3.9.1"
 openai =  { version = "^1.2.3", optional = true }
 cohere = { version = "^4.37", optional = true }
 numpy = [

--- a/tests/unit/test_bm25_tokenizer.py
+++ b/tests/unit/test_bm25_tokenizer.py
@@ -152,7 +152,7 @@ class TestBM25Tokenizer:
             language="english",
         )
 
-        nltk.find("tokenizers/punkt")
+        nltk.find("tokenizers/punkt_tab")
         nltk.find("corpora/stopwords")
 
         assert tokenizer("The quick brown fox jumps over the lazy dog") == [


### PR DESCRIPTION
Following issue https://github.com/pinecone-io/pinecone-text/issues/81 and solution suggested in https://github.com/pinecone-io/pinecone-text/pull/83 the NLTK version is upgraded to 3.9.1 to avoid the security issue described in https://github.com/nltk/nltk/issues/3293 and also to deal with the breaking change introduced.



## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Describe specific steps for validating this change.
