### PR TITLE
Adjust numpy dependency for numpy 2.0 compatibility

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -9,9 +9,17 @@ jobs:
     name: Run tests
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-latest]
-        python-version: [3.9, '3.10', 3.11, 3.12]
+        os: 
+          - macos-latest
+          - windows-latest
+          - ubuntu-latest
+        python-version: 
+          - 3.9
+          - '3.10'
+          - 3.11
+          - 3.12
     defaults:
       run:
         shell: bash
@@ -19,7 +27,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/pinecone_text/sparse/splade_encoder.py
+++ b/pinecone_text/sparse/splade_encoder.py
@@ -63,8 +63,8 @@ class SpladeEncoder(BaseSparseEncoder):
         self.device = device
 
         model = "naver/splade-cocondenser-ensembledistil"
-        self.tokenizer = AutoTokenizer.from_pretrained(model)
-        self.model = AutoModelForMaskedLM.from_pretrained(model).to(self.device)
+        self.tokenizer = AutoTokenizer.from_pretrained(model)  # type: ignore
+        self.model = AutoModelForMaskedLM.from_pretrained(model).to(self.device)  # type: ignore
         self.max_seq_length = max_seq_length
 
     def encode_documents(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,10 +15,7 @@ mmh3 = "^4.1.0"
 nltk = "^3.9.1"
 openai =  { version = "^1.2.3", optional = true }
 cohere = { version = "^4.37", optional = true }
-numpy = [
-    { version = ">=1.21.5,<3.0", python = "<4.0" },
-    { version = ">=1.26,<2.0", python = ">=3.12" }
-]
+numpy = ">=1.21.5"
 requests = "^2.25.0"
 types-requests = "^2.25.0"
 python-dotenv = "^1.0.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ nltk = "^3.9.1"
 openai =  { version = "^1.2.3", optional = true }
 cohere = { version = "^4.37", optional = true }
 numpy = [
-    { version = ">=1.21.5,<2.0", python = "<3.12" },
+    { version = ">=1.21.5,<3.0", python = "<4.0" },
     { version = ">=1.26,<2.0", python = ">=3.12" }
 ]
 requests = "^2.25.0"


### PR DESCRIPTION
## Problem

Numpy released a 2.0 major release last summer, the first major release in many years. Currently people cannot install this package alongside other code requiring numpy 2.

## Solution

Adjust dependency range, re-run tests to see. It appears we are only using numpy in a few spots within the BM25 encoder which is covered by existing unit tests.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)
