### PR TITLE
ci: add least-privilege workflow permissions (CodeQL)

### DIFF
--- a/.github/workflows/CD.yaml
+++ b/.github/workflows/CD.yaml
@@ -3,6 +3,10 @@ name: CD
 on:
   workflow_dispatch:
 
+# Release creates a git tag and a GitHub Release; PyPI publish uses PYPI_TOKEN.
+permissions:
+  contents: write
+
 jobs:
 
   release:

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -4,6 +4,10 @@ on:
   - pull_request
   - merge_group
 
+# Least-privilege default: CI only reads the repo to run tests.
+permissions:
+  contents: read
+
 jobs:
   run-tests:
     name: Run tests


### PR DESCRIPTION
## Summary
Resolves the two open CodeQL `actions/missing-workflow-permissions` alerts (#1, #2). Neither workflow declared explicit `permissions`, so both used the repository-default `GITHUB_TOKEN` scope.

## Changes
- **CI.yaml** → `permissions: contents: read` — only runs tests on `pull_request` / `merge_group`.
- **CD.yaml** → `permissions: contents: write` — creates a git tag (`git.createRef`) and a GitHub Release; the PyPI publish step uses `PYPI_TOKEN`, not `GITHUB_TOKEN`.

## Verification
- YAML parses cleanly (`ruby -ryaml`).
- Token scope now matches each workflow's actual operations; no behavior change.

Part of PIN-16 (security tail), child of PIN-6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only hardening with scopes aligned to existing checkout, test, tag, and release steps; no application code changes.
> 
> **Overview**
> Adds explicit **`permissions`** blocks to **CI** and **CD** so `GITHUB_TOKEN` scope matches what each workflow does, addressing CodeQL `actions/missing-workflow-permissions` alerts.
> 
> **CI.yaml** sets `contents: read` for pull-request and merge-group test runs. **CD.yaml** sets `contents: write` for tag and GitHub Release creation; PyPI publish still uses `PYPI_TOKEN`, not the default token.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61bc2e524db3e95fd73b17cbb1e8dadf6f137437. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->