### PR TITLE
ci: add least-privilege workflow permissions (CodeQL)

### DIFF
--- a/.github/workflows/CD.yaml
+++ b/.github/workflows/CD.yaml
@@ -3,6 +3,9 @@ name: CD
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
 
   release:

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -4,6 +4,9 @@ on:
   - pull_request
   - merge_group
 
+permissions:
+  contents: read
+
 jobs:
   run-tests:
     name: Run tests


### PR DESCRIPTION
## Summary

Adds explicit `permissions:` blocks to both GitHub Actions workflows to resolve two CodeQL `actions/missing-workflow-permissions` alerts and enforce the principle of least privilege on the default `GITHUB_TOKEN`.

- **CI.yaml** — `permissions: contents: read` (read-only test runner; no writes needed)
- **CD.yaml** — `permissions: contents: write` (creates git tags and GitHub releases via the token)

## CodeQL alerts resolved

- Alert #1: `.github/workflows/CI.yaml` — [actions/missing-workflow-permissions](https://github.com/pinecone-io/pinecone-text/security/code-scanning/1)
- Alert #2: `.github/workflows/CD.yaml` — [actions/missing-workflow-permissions](https://github.com/pinecone-io/pinecone-text/security/code-scanning/2)

## References

PIN-24

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only security hardening with permissions aligned to existing CI read and CD release behavior; no application or runtime logic changes.
> 
> **Overview**
> Adds explicit **`permissions:`** blocks to **`CI.yaml`** and **`CD.yaml`** so the default **`GITHUB_TOKEN`** is no longer granted broad repo access, addressing CodeQL **`actions/missing-workflow-permissions`** alerts.
> 
> **CI** is scoped to **`contents: read`** for checkout and test runs. **CD** is scoped to **`contents: write`** so release steps can create tags and GitHub releases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2525e4b6719c5de5f4170e9c3d38f36b0d310501. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->