### PR TITLE
fix(ci): cap torch <2.3 on Python 3.9 so poetry resolves (#101)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,13 @@ packages = [{include = "pinecone_text"}]
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
-torch = { version = ">=1.13.1", optional = true }
+# torch >=2.3 dropped Python 3.9 support (its triton/setuptools chain requires
+# Python >=3.10), so cap torch on 3.9 to keep the dependency graph resolvable.
+# See https://github.com/pinecone-io/pinecone-text/issues/101
+torch = [
+    { version = ">=1.13.1,<2.3", python = "<3.10", optional = true },
+    { version = ">=1.13.1", python = ">=3.10", optional = true },
+]
 transformers = { version = ">=4.26.1", optional = true }
 sentence-transformers = { version = ">=2.0.0", optional = true }
 mmh3 = "^4.1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,14 @@ mmh3 = "^4.1.0"
 nltk = "^3.9.1"
 openai =  { version = "^1.2.3", optional = true }
 cohere = { version = "^4.37", optional = true }
-numpy = ">=1.21.5"
+# torch <2.3 (used on Python 3.9, above) is built against the numpy 1.x ABI and
+# raises "Numpy is not available" at runtime under numpy 2.x, so cap numpy <2 on
+# Python <3.10 to match. Keep the open range on >=3.10 where torch >=2.3 supports
+# numpy 2.x. See https://github.com/pinecone-io/pinecone-text/issues/101
+numpy = [
+    { version = ">=1.21.5,<2", python = "<3.10" },
+    { version = ">=1.21.5", python = ">=3.10" },
+]
 requests = "^2.25.0"
 types-requests = "^2.25.0"
 python-dotenv = "^1.0.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,15 @@ torch = [
     { version = ">=1.13.1,<2.3", python = "<3.10", optional = true },
     { version = ">=1.13.1", python = ">=3.10", optional = true },
 ]
-transformers = { version = ">=4.26.1", optional = true }
+# transformers >=4.49 gates torch.load behind torch >=2.6 (CVE-2025-32434
+# mitigation) and raises at runtime for SPLADE models that ship as .bin. Python
+# 3.9 is capped at torch <2.3 above, so cap transformers <4.49 there to keep the
+# torch.load path working; the >=3.10 line stays open where torch >=2.6 is used.
+# See https://github.com/pinecone-io/pinecone-text/issues/101
+transformers = [
+    { version = ">=4.26.1,<4.49", python = "<3.10", optional = true },
+    { version = ">=4.26.1", python = ">=3.10", optional = true },
+]
 sentence-transformers = { version = ">=2.0.0", optional = true }
 mmh3 = "^4.1.0"
 nltk = "^3.9.1"


### PR DESCRIPTION
## What

Splits the `torch` optional dependency into per-Python constraints so Poetry can resolve the dependency graph on Python 3.9:

```toml
torch = [
    { version = ">=1.13.1,<2.3", python = "<3.10", optional = true },
    { version = ">=1.13.1", python = ">=3.10", optional = true },
]
```

## Why

The `Run tests (ubuntu-latest, 3.9)` matrix cell fails at `poetry install` on **every** PR (pre-existing, environmental). Root cause: the unbounded `torch >=1.13.1` constraint. torch ≥2.3 pulls a `triton → setuptools (>=40.8.0, py>=3.10)` chain, so no torch version satisfies the graph on Python 3.9 → version solving fails.

Capping torch to `<2.3` on Python `<3.10` (torch 2.2.2 ships 3.9 wheels) keeps 3.9 resolvable while leaving 3.10+ on the open range.

## Non-breaking

Preserves the existing `python = ">=3.9,<4.0"` support matrix rather than dropping 3.9. Dropping 3.9 (issue #101 option 1) remains a separate support-matrix decision for the maintainers; this change unblocks CI without pre-empting it.

## Verification

Local, mirroring what CI does (repo doesn't commit `poetry.lock`; CI re-resolves via `poetry install`):

- `poetry check` → `All set!`
- `poetry lock` → resolves and writes lock (torch **2.2.2** for py<3.10, newer for py≥3.10). The same command failed with `version solving failed` before this change.

Fixes #101.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging-only change in `pyproject.toml` with no application code changes; main effect is which torch versions Poetry can select on Python 3.9.
> 
> **Overview**
> Replaces the single optional `torch >=1.13.1` constraint with **Python-specific markers** so Poetry can resolve installs on **3.9**: `>=1.13.1,<2.3` when `python < 3.10`, and the previous open lower bound on **3.10+**.
> 
> This addresses CI failures on the **3.9** matrix job (`poetry install` with `--all-extras`), where **torch ≥2.3** pulls dependencies that require **Python ≥3.10**, making version solving impossible. **3.9** users who opt into torch extras are effectively capped at **2.2.x** (still within `>=1.13.1`); behavior on newer Python versions is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b08f7035e2a52b7c1d5e6482dd6de46fb34b17cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->