### PR TITLE
Allow mmh3 5.x (widen to >=4.1.0,<6.0.0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ python = ">=3.9,<4.0"
 torch = { version = ">=1.13.1", optional = true }
 transformers = { version = ">=4.26.1", optional = true }
 sentence-transformers = { version = ">=2.0.0", optional = true }
-mmh3 = "^4.1.0"
+mmh3 = ">=4.1.0,<6.0.0"
 nltk = "^3.9.1"
 openai =  { version = "^1.2.3", optional = true }
 cohere = { version = "^4.37", optional = true }


### PR DESCRIPTION
## What
Widens the `mmh3` constraint from `^4.1.0` (which caps at `<5.0.0`) to `>=4.1.0,<6.0.0`, so projects depending on pinecone-text can adopt mmh3 5.x. mmh3 4.x remains fully supported — nothing is dropped.

## Why
mmh3 5.x has been the current major since late 2024, and this package's caret pin is (in our dependency tree at least) the only thing holding downstream projects on 4.x — pip resolution fails outright for `pinecone-text==0.11.0` + `mmh3>=5`. Same situation as the mmh3 3→4 transition, which was resolved by widening the range (#76).

## Safety
- The only mmh3 call in the package is `mmh3.hash(token, signed=False)` in `pinecone_text/sparse/bm25_encoder.py`.
- MurmurHash3 output is algorithm-fixed: I verified `mmh3.hash(t, signed=False)` returns bit-identical values on 4.1.0 and 5.2.1 for ASCII and non-ASCII tokens — so existing BM25 sparse indexes are unaffected by the wider range.
- `tests/unit/test_bm25.py` + `tests/unit/test_bm25_tokenizer.py`: **21 passed** with mmh3 5.2.1 installed (Python 3.12).

The 5.x line is API/packaging modernisation (new buffer-protocol APIs, wheels for newer CPython); the `hash()` signature used here is unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only the Poetry dependency constraint changes; runtime hashing behavior is unchanged and mmh3 4.x stays supported.
> 
> **Overview**
> **Dependency-only change:** `pyproject.toml` relaxes the `mmh3` pin from `^4.1.0` (effectively `<5.0.0`) to **`>=4.1.0,<6.0.0`**, so installs can resolve `mmh3` 5.x alongside `pinecone-text` while 4.x remains allowed.
> 
> No library code changes. BM25 sparse encoding still uses `mmh3.hash(token, signed=False)` in `bm25_encoder.py`; widening the declared range does not alter that call site.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6613510b27537243412c2b58914d2912ab9c4c9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->